### PR TITLE
feat: refactor data record to allow more VIFE use-cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v0.6.0-rc.0] - 2026-06-02
+
+### Fixed
+
+- Crashes when unsupported VIFEs were used.
+- Crash when "record error" VIFE was not the first VIFE of a record.
+
+### Added
+
+- Support for more orthogonal VIFEs ("value during limit exceed", "date(/time) of")
+- Better handling of (still unsupported) orthogonal extension table (`0xFC`) to avoid crashing.
+
+### Changed
+
+- Rewrite internals around data record parsing to allow access to a (read-only) parser context.
+
 ## [v0.5.0] - 2026-03-25
 
 ### Changed

--- a/lib/exmbus/parser/apl.ex
+++ b/lib/exmbus/parser/apl.ex
@@ -4,10 +4,10 @@ defmodule Exmbus.Parser.Apl do
 
   If you don't have a TPL layer, you most likely want call the `FullFrame.parse/1` instead.
   """
-  alias Exmbus.Parser.Context
-  alias Exmbus.Parser.Apl.FullFrame
-  alias Exmbus.Parser.Apl.FormatFrame
   alias Exmbus.Parser.Apl.CompactFrame
+  alias Exmbus.Parser.Apl.FormatFrame
+  alias Exmbus.Parser.Apl.FullFrame
+  alias Exmbus.Parser.Context
 
   @doc """
   Decode the Application Layer and return one of the Apl frame structs.
@@ -15,7 +15,11 @@ defmodule Exmbus.Parser.Apl do
   The Application Layer consists of N number of records where N >= 0,
   and some optional manufacturer specific data.
 
-  The function assumes that the entire input is the APL layer data.
+  The function assumes that the remaining binary data is the APL layer data.
+
+  ## Note
+  This function dispatches to the underlying frame type parser based on the TPL layer.
+  If the TPL layer is not present, it defaults to the full frame parser.
   """
   def parse(%{tpl: %{frame_type: :full_frame}} = ctx) do
     {:next, Context.prepend_handlers(ctx, [&FullFrame.parse/1])}
@@ -27,5 +31,10 @@ defmodule Exmbus.Parser.Apl do
 
   def parse(%{tpl: %{frame_type: :compact_frame}} = ctx) do
     {:next, Context.prepend_handlers(ctx, [&CompactFrame.parse/1])}
+  end
+
+  def parse(%{tpl: nil} = ctx) do
+    # If the TPL isn't set, we assume a frame type of full_frame
+    {:next, Context.prepend_handlers(ctx, [&FullFrame.parse/1])}
   end
 end

--- a/lib/exmbus/parser/apl/data_record.ex
+++ b/lib/exmbus/parser/apl/data_record.ex
@@ -3,12 +3,11 @@ defmodule Exmbus.Parser.Apl.DataRecord do
   Parser for a DataRecord.
   """
 
-  alias Exmbus.Parser.Apl.DataRecord.CompactProfile
   alias Exmbus.Parser.Apl.DataRecord
+  alias Exmbus.Parser.Apl.DataRecord.CompactProfile
   alias Exmbus.Parser.Apl.DataRecord.Header
   alias Exmbus.Parser.Apl.DataRecord.Header.InvalidHeader
   alias Exmbus.Parser.Apl.DataRecord.ValueInformationBlock, as: VIB
-  # alias Exmbus.Parser.Apl.DataRecord.DataInformationBlock, as: DIB
   alias Exmbus.Parser.DataType
 
   defdelegate compact_profile?(data_record), to: CompactProfile
@@ -38,8 +37,8 @@ defmodule Exmbus.Parser.Apl.DataRecord do
   @doc """
   Decodes a single DataRecord from a binary.
   """
-  def parse(bin, ctx) do
-    case Header.parse(bin, ctx) do
+  def parse(bin, read_only_ctx) do
+    case Header.parse(bin, read_only_ctx) do
       {:ok, %Header{} = header, rest} ->
         case parse_data(header, rest) do
           {:ok, data, rest} ->
@@ -310,15 +309,25 @@ defmodule Exmbus.Parser.Apl.DataRecord do
     do: DataType.encode_type_d(data, size)
 
   # Datetime 32bit (Type F)
-  def unparse_data(%{coding: :type_f, dib: %{size: 32}}, data), do: DataType.encode_type_f(data)
+  def unparse_data(%{coding: :type_f, dib: %{size: 32}}, data),
+    do: DataType.encode_type_f(data)
+
   # Date (Type G)
-  def unparse_data(%{coding: :type_g, dib: %{size: 16}}, data), do: DataType.encode_type_g(data)
+  def unparse_data(%{coding: :type_g, dib: %{size: 16}}, data),
+    do: DataType.encode_type_g(data)
+
   # Real 32 bit (Type H)
-  def unparse_data(%{coding: :type_h, dib: %{size: 32}}, data), do: DataType.encode_type_h(data)
+  def unparse_data(%{coding: :type_h, dib: %{size: 32}}, data),
+    do: DataType.encode_type_h(data)
+
   # Datetime 48 bit (Type I)
-  def unparse_data(%{coding: :type_i, dib: %{size: 48}}, data), do: DataType.encode_type_i(data)
+  def unparse_data(%{coding: :type_i, dib: %{size: 48}}, data),
+    do: DataType.encode_type_i(data)
+
   # Time 24 bit (Type J)
-  def unparse_data(%{coding: :type_j, dib: %{size: 24}}, data), do: DataType.encode_type_j(data)
+  def unparse_data(%{coding: :type_j, dib: %{size: 24}}, data),
+    do: DataType.encode_type_j(data)
+
   # Datetime in LVAR (Type M)
   def unparse_data(%{coding: :type_m, dib: %{size: :variable_length}}, data),
     do: DataType.encode_type_m(data)

--- a/lib/exmbus/parser/apl/data_record/compact_profile.ex
+++ b/lib/exmbus/parser/apl/data_record/compact_profile.ex
@@ -27,9 +27,9 @@ defmodule Exmbus.Parser.Apl.DataRecord.CompactProfile do
   Compact Profiles are automatically expanded by default.
   This can be disabled with the option `expand_compact_profiles: false` in the options map.
   """
-  alias Exmbus.Parser.Context
-  alias Exmbus.Parser.Apl.DataRecord.CompactProfile.CompactProfileHeader
   alias Exmbus.Parser.Apl.DataRecord
+  alias Exmbus.Parser.Apl.DataRecord.CompactProfile.CompactProfileHeader
+  alias Exmbus.Parser.Context
 
   @doc """
   Return true if the record is a compact profile record. false otherwise.

--- a/lib/exmbus/parser/apl/data_record/header.ex
+++ b/lib/exmbus/parser/apl/data_record/header.ex
@@ -36,8 +36,8 @@ defmodule Exmbus.Parser.Apl.DataRecord.Header do
   @doc """
   Parses the next DataRecord Header from a binary.
   """
-  def parse(bin, ctx) do
-    case DIB.parse(bin, ctx) do
+  def parse(bin, read_only_ctx) do
+    case DIB.parse(bin, read_only_ctx) do
       {:special_function, type, rest_after_dib} ->
         # we just return the special function. The parser upstream will have to decide what to do,
         # but there isn't a real header here. The APL layer knows what to do.
@@ -47,7 +47,7 @@ defmodule Exmbus.Parser.Apl.DataRecord.Header do
         # We found a DataInformationBlock.
         # We now expect a VIB to follow, which needs the context from the DIB to be able to parse
         # correctly.
-        case VIB.parse(rest_after_dib, %{ctx | dib: dib}) do
+        case VIB.parse(rest_after_dib, dib, read_only_ctx) do
           {:ok, %VIB{} = vib, rest_after_vib} ->
             dib_size = byte_size(bin) - byte_size(rest_after_dib)
             vib_size = byte_size(rest_after_dib) - byte_size(rest_after_vib)

--- a/lib/exmbus/parser/apl/data_record/value_information_block.ex
+++ b/lib/exmbus/parser/apl/data_record/value_information_block.ex
@@ -3,6 +3,7 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock do
   The Value Information Block utilities
   """
   alias __MODULE__, as: VIB
+  alias Exmbus.Parser.Apl.DataRecord.DataInformationBlock, as: DIB
   alias Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableMain
   alias Exmbus.Parser.Context
 
@@ -52,11 +53,11 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock do
     table: nil
   ]
 
-  @spec parse(binary, Context.t()) ::
+  @spec parse(binary(), DIB.t(), Context.t()) ::
           {:ok, VIB.t(), rest :: binary} | {:error, any, binary}
-  def parse(bin, ctx) do
+  def parse(bin, %DIB{} = dib, %Context{} = read_only_ctx) do
     # delegate the parsing to the primary table
-    VifTableMain.parse(bin, ctx)
+    VifTableMain.parse(bin, dib, read_only_ctx)
   end
 
   # Basic unparse, main table, no extensions

--- a/lib/exmbus/parser/apl/data_record/value_information_block/vif_table_fb.ex
+++ b/lib/exmbus/parser/apl/data_record/value_information_block/vif_table_fb.ex
@@ -8,39 +8,39 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableFB do
   alias Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.Vife
 
   # Table 0xFB from table 14 in EN 13757-3:2018 section 6.4.5
-  def parse(<<e::1, 0b000000::6, n::1, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :energy, multiplier: pow10to(n-1), unit: "MWh"}})
-  def parse(<<e::1, 0b000001::6, n::1, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :reactive_energy, multiplier: pow10to(n), unit: "kVARh"}})
-  def parse(<<e::1, 0b000010::6, n::1, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :apparent_energy, multiplier: pow10to(n), unit: "kVAh"}})
-  def parse(<<e::1, 0b000011::6, _::1, rest::binary>>, ctx),  do: Vife.error(e, rest, {:reserved, "VIF E000011n reserved"}, ctx)
-  def parse(<<e::1, 0b000100::6, n::1, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :energy, multiplier: pow10to(n-1), unit: "GJ"}})
-  def parse(<<e::1, 0b000101::6, _::1, rest::binary>>, ctx),  do: Vife.error(e, rest, {:reserved, "VIF E000101n reserved"}, ctx)
-  def parse(<<e::1, 0b00011::5, nn::2, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :energy, multiplier: pow10to(nn-1), unit: "MCal"}})
-  def parse(<<e::1, 0b001000::6, n::1, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :volume, multiplier: pow10to(n+2), unit: "m^3"}})
-  def parse(<<e::1, 0b001001::6, _::1, rest::binary>>, ctx),  do: Vife.error(e, rest, {:reserved, "VIF E001001n reserved"}, ctx)
-  def parse(<<e::1, 0b00101::5, nn::2, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :reactive_power, multiplier: pow10to(nn-3), unit: "kVAR"}})
-  def parse(<<e::1, 0b001100::6, n::1, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, coding: fb_remark_d(ctx), description: :mass, multiplier: pow10to(n+2), unit: "t"}})
-  def parse(<<e::1, 0b001101::6, n::1, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, coding: fb_remark_d(ctx), description: :relative_humidity, multiplier: pow10to(n-1), unit: "%"}})
-  def parse(<<e::1, n::7, rest::binary>>, ctx) when n >= 0b001_1100 and n <= 0b001_1111, do: Vife.error(e, rest, {:reserved, "VIF E0011100 - E0011111 reserved"}, ctx)
-  def parse(<<e::1, 0b0100000::7, rest::binary>>, ctx),        do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :volume, unit: "ft^3"}})
-  def parse(<<e::1, 0b0100001::7, rest::binary>>, ctx),        do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :volume, multiplier: 0.1, unit: "ft^3"}})
-  def parse(<<e::1, n::7, rest::binary>>, ctx) when n >= 0b010_0010 and n <= 0b010_0111, do: Vife.error(e, rest, {:reserved, "VIF E0100010 - E0100111 were used until 2004, now they are reserved for future use."}, ctx)
-  def parse(<<e::1, 0b010100::6, n::1, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :power, multiplier: pow10to(n-1), unit: "MW"}})
-  def parse(<<e::1, 0b0101010::7, rest::binary>>, ctx),        do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :phase_volt_to_volt, unit: "°"}})
-  def parse(<<e::1, 0b0101011::7, rest::binary>>, ctx),        do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :phase_volt_to_current, unit: "°"}})
-  def parse(<<e::1, 0b01011::5, nn::2, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :frequency, multiplier: pow10to(nn-3), unit: "Hz"}})
-  def parse(<<e::1, 0b011000::6, n::1, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :power, multiplier: pow10to(n-1), unit: "GJ/h"}})
-  def parse(<<e::1, 0b011001::6, _::1, rest::binary>>, ctx),  do: Vife.error(e, rest, {:reserved, "VIF E011001n reserved"}, ctx)
-  def parse(<<e::1, 0b01101::5, nn::2, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :apparent_power, multiplier: pow10to(nn-3), unit: "kVA"}})
-  def parse(<<e::1, n::7, rest::binary>>, ctx) when n >= 0b0111000 and n <= 0b1010111, do: Vife.error(e, rest, {:reserved, "E0111000 - E1010111 reserved"}, ctx)
-  def parse(<<e::1, n::7, rest::binary>>, ctx) when n >= 0b010_0010 and n <= 0b010_0111, do: Vife.error(e, rest, {:reserved, "VIF E1011000 - E1100111 were used until 2004, now they are reserved for future use."}, ctx)
-  def parse(<<e::1, 0b11101::5, nn::2, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :temperature_limit, multiplier: pow10to(nn-3), unit: "°C"}})
-  def parse(<<e::1, 0b1111::4, nnn::3, rest::binary>>, ctx),   do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, description: :cumulative_max_active_power, multiplier: pow10to(nnn-3), unit: "W"}})
-  def parse(<<e::1, 0b1101000::7, rest::binary>>, ctx),        do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, coding: fb_remark_d(ctx), description: :resulting_rating_factor_k, multiplier: pow2to(-12), unit: "units for HCA"}})
-  def parse(<<e::1, 0b1101001::7, rest::binary>>, ctx),        do: Vife.parse(e, rest, %{ctx| vib: %VIB{table: :fb, coding: fb_remark_d(ctx), description: :thermal_output_rating_factor_kq, multiplier: pow2to(-12), unit: "W"}})
+  def parse(<<e::1, 0b000000::6, n::1, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :energy, multiplier: pow10to(n-1), unit: "MWh"}, ctx)
+  def parse(<<e::1, 0b000001::6, n::1, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :reactive_energy, multiplier: pow10to(n), unit: "kVARh"}, ctx)
+  def parse(<<e::1, 0b000010::6, n::1, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :apparent_energy, multiplier: pow10to(n), unit: "kVAh"}, ctx)
+  def parse(<<e::1, 0b000011::6, _::1, rest::binary>>, dib, ctx),  do: Vife.error(e, rest, dib, ctx, {:reserved, "VIF E000011n reserved"})
+  def parse(<<e::1, 0b000100::6, n::1, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :energy, multiplier: pow10to(n-1), unit: "GJ"}, ctx)
+  def parse(<<e::1, 0b000101::6, _::1, rest::binary>>, dib, ctx),  do: Vife.error(e, rest, dib, ctx, {:reserved, "VIF E000101n reserved"})
+  def parse(<<e::1, 0b00011::5, nn::2, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :energy, multiplier: pow10to(nn-1), unit: "MCal"}, ctx)
+  def parse(<<e::1, 0b001000::6, n::1, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :volume, multiplier: pow10to(n+2), unit: "m^3"}, ctx)
+  def parse(<<e::1, 0b001001::6, _::1, rest::binary>>, dib, ctx),  do: Vife.error(e, rest, dib, ctx, {:reserved, "VIF E001001n reserved"})
+  def parse(<<e::1, 0b00101::5, nn::2, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :reactive_power, multiplier: pow10to(nn-3), unit: "kVAR"}, ctx)
+  def parse(<<e::1, 0b001100::6, n::1, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, coding: fb_remark_d(dib), description: :mass, multiplier: pow10to(n+2), unit: "t"}, ctx)
+  def parse(<<e::1, 0b001101::6, n::1, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, coding: fb_remark_d(dib), description: :relative_humidity, multiplier: pow10to(n-1), unit: "%"}, ctx)
+  def parse(<<e::1, n::7, rest::binary>>, dib, ctx) when n >= 0b001_1100 and n <= 0b001_1111, do: Vife.error(e, rest, dib, ctx, {:reserved, "VIF E0011100 - E0011111 reserved"})
+  def parse(<<e::1, 0b0100000::7, rest::binary>>, dib, ctx),        do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :volume, unit: "ft^3"}, ctx)
+  def parse(<<e::1, 0b0100001::7, rest::binary>>, dib, ctx),        do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :volume, multiplier: 0.1, unit: "ft^3"}, ctx)
+  def parse(<<e::1, n::7, rest::binary>>, dib, ctx) when n >= 0b010_0010 and n <= 0b010_0111, do: Vife.error(e, rest, dib, ctx, {:reserved, "VIF E0100010 - E0100111 were used until 2004, now they are reserved for future use."})
+  def parse(<<e::1, 0b010100::6, n::1, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :power, multiplier: pow10to(n-1), unit: "MW"}, ctx)
+  def parse(<<e::1, 0b0101010::7, rest::binary>>, dib, ctx),        do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :phase_volt_to_volt, unit: "°"}, ctx)
+  def parse(<<e::1, 0b0101011::7, rest::binary>>, dib, ctx),        do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :phase_volt_to_current, unit: "°"}, ctx)
+  def parse(<<e::1, 0b01011::5, nn::2, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :frequency, multiplier: pow10to(nn-3), unit: "Hz"}, ctx)
+  def parse(<<e::1, 0b011000::6, n::1, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :power, multiplier: pow10to(n-1), unit: "GJ/h"}, ctx)
+  def parse(<<e::1, 0b011001::6, _::1, rest::binary>>, dib, ctx),  do: Vife.error(e, rest, dib, ctx, {:reserved, "VIF E011001n reserved"})
+  def parse(<<e::1, 0b01101::5, nn::2, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :apparent_power, multiplier: pow10to(nn-3), unit: "kVA"}, ctx)
+  def parse(<<e::1, n::7, rest::binary>>, dib, ctx) when n >= 0b0111000 and n <= 0b1010111, do: Vife.error(e, rest, dib, ctx, {:reserved, "E0111000 - E1010111 reserved"})
+  def parse(<<e::1, n::7, rest::binary>>, dib, ctx) when n >= 0b1011000 and n <= 0b1100111, do: Vife.error(e, rest, dib, ctx, {:reserved, "VIF E1011000 - E1100111 were used until 2004, now they are reserved for future use."})
+  def parse(<<e::1, 0b11101::5, nn::2, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :temperature_limit, multiplier: pow10to(nn-3), unit: "°C"}, ctx)
+  def parse(<<e::1, 0b1111::4, nnn::3, rest::binary>>, dib, ctx),   do: Vife.parse(e, rest, dib, %VIB{table: :fb, description: :cumulative_max_active_power, multiplier: pow10to(nnn-3), unit: "W"}, ctx)
+  def parse(<<e::1, 0b1101000::7, rest::binary>>, dib, ctx),        do: Vife.parse(e, rest, dib, %VIB{table: :fb, coding: fb_remark_d(dib), description: :resulting_rating_factor_k, multiplier: pow2to(-12), unit: "units for HCA"}, ctx)
+  def parse(<<e::1, 0b1101001::7, rest::binary>>, dib, ctx),        do: Vife.parse(e, rest, dib, %VIB{table: :fb, coding: fb_remark_d(dib), description: :thermal_output_rating_factor_kq, multiplier: pow2to(-12), unit: "W"}, ctx)
   # skipping some HCA things here
 
-  def parse(<<vif, _rest::binary>>, ctx) do
-    raise "decoding from VIF linear extension table 0xFB not implemented. VIFE was: #{Exmbus.Debug.to_bits(vif)}, ctx was: #{inspect ctx}"
+  def parse(<<vif, _rest::binary>>, dib, ctx) do
+    raise "decoding from VIF linear extension table 0xFB not implemented. VIFE was: #{Exmbus.Debug.to_bits(vif)}, dib was: #{inspect dib} ctx was: #{inspect ctx}"
   end
 
 
@@ -53,13 +53,13 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableFB do
   # Maybe what it SHOULD have set is that if the coding is int/binary then do type C, if it's BCD then do type A.
   # Or maybe it says that the binary (as in the raw) data should be decoded as either BCD or UINT, and
   # anything else is an error, but that also seems weird for something like manufacturer, customer, etc.
-  defp fb_remark_d(%{dib: %DIB{data_type: :int_or_bin}}) do
+  defp fb_remark_d(%DIB{data_type: :int_or_bin}) do
     :type_c
   end
-  defp fb_remark_d(%{dib: %DIB{data_type: :variable_length}}) do
+  defp fb_remark_d(%DIB{data_type: :variable_length}) do
     nil # lvar coding is determined by the lvar
   end
-  defp fb_remark_d(%{dib: %DIB{data_type: :bcd}}) do
+  defp fb_remark_d(%DIB{data_type: :bcd}) do
     :type_a
   end
 

--- a/lib/exmbus/parser/apl/data_record/value_information_block/vif_table_fd.ex
+++ b/lib/exmbus/parser/apl/data_record/value_information_block/vif_table_fd.ex
@@ -10,70 +10,70 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableFD do
   ##
   ## The FD table
   ##
-  def parse(<<_::1, 0b000_00::5, _nn::2>>, _ctx), do: raise "0xFD vif 0bE00000nn not supported. Credit of 10^(nn–3) of the nominal local legal currency units."
-  def parse(<<_::1, 0b000_01::5, _nn::2>>, _ctx), do: raise "0xFD vif 0bE00000nn not supported. Debit of 10^(nn–3) of the nominal local legal currency units."
-  def parse(<<e::1, 0b000_1000::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :unique_message_identification}})
-  def parse(<<e::1, 0b000_1001::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :device_type}})
-  def parse(<<e::1, 0b000_1010::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :manufacturer}})
-  def parse(<<e::1, 0b000_1011::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :parameter_set_identification}})
-  def parse(<<e::1, 0b000_1100::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :model_version}})
-  def parse(<<e::1, 0b000_1101::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :hardware_version_number}})
-  def parse(<<e::1, 0b000_1110::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :firmware_version_number}})
-  def parse(<<e::1, 0b000_1111::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :other_software_version_number}})
-  def parse(<<e::1, 0b001_0000::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :customer_location}})
-  def parse(<<e::1, 0b001_0001::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :customer}})
-  def parse(<<e::1, 0b001_0010::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :access_code_user}})
-  def parse(<<e::1, 0b001_0011::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :access_code_operator}})
-  def parse(<<e::1, 0b001_0100::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :access_code_system_operator}})
-  def parse(<<e::1, 0b001_0101::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :access_code_developer}})
-  def parse(<<e::1, 0b001_0110::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :password}})
-  def parse(<<e::1, 0b001_0111::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: :type_d, description: :error_flags}})
-  def parse(<<e::1, 0b001_1000::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :error_mask}})
-  def parse(<<e::1, 0b001_1001::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :security_key}})
-  def parse(<<e::1, 0b001_1010::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :digital_output}})
-  def parse(<<e::1, 0b001_1011::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :digital_input}})
-  def parse(<<e::1, 0b001_1100::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :baud_rate}})
-  def parse(<<e::1, 0b001_1101::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :response_delay_time}})
-  def parse(<<e::1, 0b001_1110::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :retry}})
-  def parse(<<e::1, 0b001_1111::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :remote_control}})
-  def parse(<<e::1, 0b010_0000::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :first_storage_number_for_cyclic_storage}})
-  def parse(<<e::1, 0b010_0001::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :last_storage_number_for_cyclic_storage}})
-  def parse(<<e::1, 0b010_0010::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :size_of_storage_block}})
-  def parse(<<e::1, 0b010_0011::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :descriptor_for_tariff_and_device}})
-  def parse(<<e::1, 0b010_01::5, nn::2, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :storage_interval, unit: on_time_unit(nn)}})
-  def parse(<<e::1, 0b010_1000::7, rest::binary>>,      ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: {:storage_interval, :month}}})
-  def parse(<<e::1, 0b010_1001::7, rest::binary>>,      ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: {:storage_interval, :year}}})
-  def parse(<<e::1, 0b010_1010::7, rest::binary>>,      ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :operator_specific_data}})
-  def parse(<<e::1, 0b010_1011::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :time_point_second}})
-  def parse(<<e::1, 0b010_11::5, 0b00::2, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: {:duration_size_last_readout, :second}}})
-  def parse(<<e::1, 0b010_11::5, 0b01::2, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: {:duration_size_last_readout, :minute}}})
-  def parse(<<e::1, 0b010_11::5, 0b10::2, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: {:duration_size_last_readout, :hour}}})
-  def parse(<<e::1, 0b010_11::5, 0b11::2, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: {:duration_size_last_readout, :day}}})
+  def parse(<<_::1, 0b000_00::5, _nn::2>>, _dib, _ctx), do: raise "0xFD vif 0bE00000nn not supported. Credit of 10^(nn–3) of the nominal local legal currency units."
+  def parse(<<_::1, 0b000_01::5, _nn::2>>, _dib, _ctx), do: raise "0xFD vif 0bE00000nn not supported. Debit of 10^(nn–3) of the nominal local legal currency units."
+  def parse(<<e::1, 0b000_1000::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :unique_message_identification}, ctx)
+  def parse(<<e::1, 0b000_1001::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :device_type}, ctx)
+  def parse(<<e::1, 0b000_1010::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :manufacturer}, ctx)
+  def parse(<<e::1, 0b000_1011::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :parameter_set_identification}, ctx)
+  def parse(<<e::1, 0b000_1100::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :model_version}, ctx)
+  def parse(<<e::1, 0b000_1101::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :hardware_version_number}, ctx)
+  def parse(<<e::1, 0b000_1110::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :firmware_version_number}, ctx)
+  def parse(<<e::1, 0b000_1111::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :other_software_version_number}, ctx)
+  def parse(<<e::1, 0b001_0000::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :customer_location}, ctx)
+  def parse(<<e::1, 0b001_0001::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :customer}, ctx)
+  def parse(<<e::1, 0b001_0010::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :access_code_user}, ctx)
+  def parse(<<e::1, 0b001_0011::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :access_code_operator}, ctx)
+  def parse(<<e::1, 0b001_0100::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :access_code_system_operator}, ctx)
+  def parse(<<e::1, 0b001_0101::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :access_code_developer}, ctx)
+  def parse(<<e::1, 0b001_0110::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :password}, ctx)
+  def parse(<<e::1, 0b001_0111::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: :type_d, description: :error_flags}, ctx)
+  def parse(<<e::1, 0b001_1000::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :error_mask}, ctx)
+  def parse(<<e::1, 0b001_1001::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :security_key}, ctx)
+  def parse(<<e::1, 0b001_1010::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :digital_output}, ctx)
+  def parse(<<e::1, 0b001_1011::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :digital_input}, ctx)
+  def parse(<<e::1, 0b001_1100::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :baud_rate}, ctx)
+  def parse(<<e::1, 0b001_1101::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :response_delay_time}, ctx)
+  def parse(<<e::1, 0b001_1110::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :retry}, ctx)
+  def parse(<<e::1, 0b001_1111::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :remote_control}, ctx)
+  def parse(<<e::1, 0b010_0000::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :first_storage_number_for_cyclic_storage}, ctx)
+  def parse(<<e::1, 0b010_0001::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :last_storage_number_for_cyclic_storage}, ctx)
+  def parse(<<e::1, 0b010_0010::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :size_of_storage_block}, ctx)
+  def parse(<<e::1, 0b010_0011::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :descriptor_for_tariff_and_device}, ctx)
+  def parse(<<e::1, 0b010_01::5, nn::2, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :storage_interval, unit: on_time_unit(nn)}, ctx)
+  def parse(<<e::1, 0b010_1000::7, rest::binary>>,      dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: {:storage_interval, :month}}, ctx)
+  def parse(<<e::1, 0b010_1001::7, rest::binary>>,      dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: {:storage_interval, :year}}, ctx)
+  def parse(<<e::1, 0b010_1010::7, rest::binary>>,      dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :operator_specific_data}, ctx)
+  def parse(<<e::1, 0b010_1011::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :time_point_second}, ctx)
+  def parse(<<e::1, 0b010_11::5, 0b00::2, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: {:duration_size_last_readout, :second}}, ctx)
+  def parse(<<e::1, 0b010_11::5, 0b01::2, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: {:duration_size_last_readout, :minute}}, ctx)
+  def parse(<<e::1, 0b010_11::5, 0b10::2, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: {:duration_size_last_readout, :hour}}, ctx)
+  def parse(<<e::1, 0b010_11::5, 0b11::2, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: {:duration_size_last_readout, :day}}, ctx)
   # Tariff related VIFs
-  def parse(<<e::1, 0b0110000::7, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :start_of_tariff}})
-  def parse(<<e::1, 0b01100::5, 0b01::2, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: {:duration_of_tariff, :minute}}})
-  def parse(<<e::1, 0b01100::5, 0b10::2, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: {:duration_of_tariff, :hour}}})
-  def parse(<<e::1, 0b01100::5, 0b11::2, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: {:duration_of_tariff, :day}}})
+  def parse(<<e::1, 0b0110000::7, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :start_of_tariff}, ctx)
+  def parse(<<e::1, 0b01100::5, 0b01::2, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: {:duration_of_tariff, :minute}}, ctx)
+  def parse(<<e::1, 0b01100::5, 0b10::2, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: {:duration_of_tariff, :hour}}, ctx)
+  def parse(<<e::1, 0b01100::5, 0b11::2, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: {:duration_of_tariff, :day}}, ctx)
   # ... skipped some vifs ...
-  def parse(<<e::1, 0b011_1010::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :dimensionless}})
-  def parse(<<e::1, 0b011_1011::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: {:container, :wmbus}}})
-  def parse(<<e::1, 0b011_11::5, nn::2, rest::binary>>, ctx), do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :period_of_nominal_data_transmissions, unit: on_time_unit(nn)}})
-  def parse(<<e::1, 0b100::3, nnnn::4, rest::binary>>, ctx),  do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :volts, multiplier: pow10to(nnnn-9), unit: "V"}})
-  def parse(<<e::1, 0b101::3, nnnn::4, rest::binary>>, ctx),  do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :amperes, multiplier: pow10to(nnnn-12), unit: "A"}})
+  def parse(<<e::1, 0b011_1010::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :dimensionless}, ctx)
+  def parse(<<e::1, 0b011_1011::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: {:container, :wmbus}}, ctx)
+  def parse(<<e::1, 0b011_11::5, nn::2, rest::binary>>, dib, ctx), do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :period_of_nominal_data_transmissions, unit: on_time_unit(nn)}, ctx)
+  def parse(<<e::1, 0b100::3, nnnn::4, rest::binary>>, dib, ctx),  do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :volts, multiplier: pow10to(nnnn-9), unit: "V"}, ctx)
+  def parse(<<e::1, 0b101::3, nnnn::4, rest::binary>>, dib, ctx),  do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :amperes, multiplier: pow10to(nnnn-12), unit: "A"}, ctx)
   # ... skipped some vifs ...
-  def parse(<<e::1, 0b110_0000::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :reset_counter}})
-  def parse(<<e::1, 0b110_0001::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :cumulation_counter}})
+  def parse(<<e::1, 0b110_0000::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :reset_counter}, ctx)
+  def parse(<<e::1, 0b110_0001::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :cumulation_counter}, ctx)
   # ... skipped some vifs ...
-  def parse(<<e::1, 0b110_0110::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :state_of_parameter_activation}})
+  def parse(<<e::1, 0b110_0110::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :state_of_parameter_activation}, ctx)
   # ... skipped some vifs ...
-  def parse(<<e::1, 0b111_0001::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: :rf_level_units_dbm}})
+  def parse(<<e::1, 0b111_0001::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: :rf_level_units_dbm}, ctx)
   # ... skipped some vifs ...
-  def parse(<<e::1, 0b111_0100::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :remaining_battery_life_time_days}})
-  def parse(<<e::1, 0b111_0101::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, coding: fd_remark_k(ctx), description: :number_of_times_meter_was_stopped}})
-  def parse(<<e::1, 0b111_0110::7, rest::binary>>, ctx),      do: Vife.parse(e, rest, %{ctx | vib: %VIB{table: :fd, description: {:container, :manufacturer}}})
+  def parse(<<e::1, 0b111_0100::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :remaining_battery_life_time_days}, ctx)
+  def parse(<<e::1, 0b111_0101::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, coding: fd_remark_k(dib), description: :number_of_times_meter_was_stopped}, ctx)
+  def parse(<<e::1, 0b111_0110::7, rest::binary>>, dib, ctx),      do: Vife.parse(e, rest, dib, %VIB{table: :fd, description: {:container, :manufacturer}}, ctx)
   # ... skipped some vifs ...
-  def parse(<<e::1, vif::7, rest::binary>>, ctx) do
-    raise "decoding from VIF linear extension table 0xFD not implemented. VIFE was: #{Exmbus.Debug.to_hex(vif)} (E#{Exmbus.Debug.to_bits(<<vif::7>>)}) (E=#{e}), ctx was: #{inspect ctx}, rest was: #{inspect rest}"
+  def parse(<<e::1, vif::7, rest::binary>>, dib, ctx) do
+    raise "decoding from VIF linear extension table 0xFD not implemented. VIFE was: #{Exmbus.Debug.to_hex(vif)} (E#{Exmbus.Debug.to_bits(<<vif::7>>)}) (E=#{e}), dib was: #{inspect dib} ctx was: #{inspect ctx}, rest was: #{inspect rest}"
   end
 
 
@@ -86,13 +86,13 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableFD do
   # Maybe what it SHOULD have set is that if the coding is int/binary then do type C, if it's BCD then do type A.
   # Or maybe it says that the binary (as in the raw) data should be decoded as either BCD or UINT, and
   # anything else is an error, but that also seems weird for something like manufacturer, customer, etc.
-  defp fd_remark_k(%{dib: %DIB{data_type: :int_or_bin}}) do
+  defp fd_remark_k(%DIB{data_type: :int_or_bin}) do
     :type_c
   end
-  defp fd_remark_k(%{dib: %DIB{data_type: :variable_length}}) do
+  defp fd_remark_k(%DIB{data_type: :variable_length}) do
     nil # lvar coding is determined by the lvar
   end
-  defp fd_remark_k(%{dib: %DIB{data_type: :bcd}}) do
+  defp fd_remark_k(%DIB{data_type: :bcd}) do
     :type_a
   end
 

--- a/lib/exmbus/parser/apl/data_record/value_information_block/vif_table_main.ex
+++ b/lib/exmbus/parser/apl/data_record/value_information_block/vif_table_main.ex
@@ -7,13 +7,13 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableMain do
 
   alias Exmbus.Parser.Apl.DataRecord.DataInformationBlock, as: DIB
   alias Exmbus.Parser.Apl.DataRecord.ValueInformationBlock, as: VIB
+  alias Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.Vife
   alias Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableFB, as: FB
   alias Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableFD, as: FD
-  alias Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.Vife
 
 
   # helper to transition the parser into VIFE parsing.
-  defp more(e, rest, ctx, description, keywords \\ []) do
+  defp more(e, rest, dib, ctx, description, keywords \\ []) do
     vib = %VIB{
       table: :main,
       description: description,
@@ -23,59 +23,59 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableMain do
       coding: Keyword.get(keywords, :coding, nil)
     }
 
-    Vife.parse(e, rest, %{ctx | vib: vib})
+    Vife.parse(e, rest, dib, vib, ctx)
   end
 
   ###
   # primary VIF table decoding
   ###
-  def parse(<<e::1, 0b0000::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :energy,                 multiplier: pow10to(n-3), unit: "Wh")
-  def parse(<<e::1, 0b0001::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :energy,                 multiplier: pow10to(n),   unit: "J")
-  def parse(<<e::1, 0b0010::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :volume,                 multiplier: pow10to(n-6), unit: "m^3")
-  def parse(<<e::1, 0b0011::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :mass,                   multiplier: pow10to(n-6), unit: "kg")
-  def parse(<<e::1, 0b01000::5, n::2, rest::binary>>, ctx),  do: more(e, rest, ctx, :on_time,                unit:  decode_time_unit(n))
-  def parse(<<e::1, 0b01001::5, n::2, rest::binary>>, ctx),  do: more(e, rest, ctx, :operating_time,         unit:  decode_time_unit(n))
-  def parse(<<e::1, 0b0101::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :power,                  multiplier: pow10to(n-3), unit: "W")
-  def parse(<<e::1, 0b0110::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :power,                  multiplier: pow10to(n),   unit: "J/h")
-  def parse(<<e::1, 0b0111::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :volume_flow,            multiplier: pow10to(n-6), unit: "m^3/h")
-  def parse(<<e::1, 0b1000::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :volume_flow_ext,        multiplier: pow10to(n-7), unit: "m^3/min")
-  def parse(<<e::1, 0b1001::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :volume_flow_ext,        multiplier: pow10to(n-9), unit: "m^3/s")
-  def parse(<<e::1, 0b1010::4,  n::3, rest::binary>>, ctx),  do: more(e, rest, ctx, :mass_flow,              multiplier: pow10to(n-3), unit: "kg/h")
-  def parse(<<e::1, 0b10110::5, n::2, rest::binary>>, ctx),  do: more(e, rest, ctx, :flow_temperature,       multiplier: pow10to(n-3), unit: "°C")
-  def parse(<<e::1, 0b10111::5, n::2, rest::binary>>, ctx),  do: more(e, rest, ctx, :return_temperature,     multiplier: pow10to(n-3), unit: "°C")
-  def parse(<<e::1, 0b11000::5, n::2, rest::binary>>, ctx),  do: more(e, rest, ctx, :temperature_difference, multiplier: pow10to(n-3), unit: "K")
-  def parse(<<e::1, 0b11001::5, n::2, rest::binary>>, ctx),  do: more(e, rest, ctx, :external_temperature,   multiplier: pow10to(n-3), unit: "°C")
-  def parse(<<e::1, 0b11010::5, n::2, rest::binary>>, ctx),  do: more(e, rest, ctx, :pressure,               multiplier: pow10to(n-3), unit: "bar")
+  def parse(<<e::1, 0b0000::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :energy,                 multiplier: pow10to(n-3), unit: "Wh")
+  def parse(<<e::1, 0b0001::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :energy,                 multiplier: pow10to(n),   unit: "J")
+  def parse(<<e::1, 0b0010::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :volume,                 multiplier: pow10to(n-6), unit: "m^3")
+  def parse(<<e::1, 0b0011::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :mass,                   multiplier: pow10to(n-6), unit: "kg")
+  def parse(<<e::1, 0b01000::5, n::2, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :on_time,                unit:  decode_time_unit(n))
+  def parse(<<e::1, 0b01001::5, n::2, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :operating_time,         unit:  decode_time_unit(n))
+  def parse(<<e::1, 0b0101::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :power,                  multiplier: pow10to(n-3), unit: "W")
+  def parse(<<e::1, 0b0110::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :power,                  multiplier: pow10to(n),   unit: "J/h")
+  def parse(<<e::1, 0b0111::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :volume_flow,            multiplier: pow10to(n-6), unit: "m^3/h")
+  def parse(<<e::1, 0b1000::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :volume_flow_ext,        multiplier: pow10to(n-7), unit: "m^3/min")
+  def parse(<<e::1, 0b1001::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :volume_flow_ext,        multiplier: pow10to(n-9), unit: "m^3/s")
+  def parse(<<e::1, 0b1010::4,  n::3, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :mass_flow,              multiplier: pow10to(n-3), unit: "kg/h")
+  def parse(<<e::1, 0b10110::5, n::2, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :flow_temperature,       multiplier: pow10to(n-3), unit: "°C")
+  def parse(<<e::1, 0b10111::5, n::2, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :return_temperature,     multiplier: pow10to(n-3), unit: "°C")
+  def parse(<<e::1, 0b11000::5, n::2, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :temperature_difference, multiplier: pow10to(n-3), unit: "K")
+  def parse(<<e::1, 0b11001::5, n::2, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :external_temperature,   multiplier: pow10to(n-3), unit: "°C")
+  def parse(<<e::1, 0b11010::5, n::2, rest::binary>>, dib, ctx),  do: more(e, rest, dib, ctx, :pressure,               multiplier: pow10to(n-3), unit: "bar")
   # TYPE: Date and Time
   # - Data field 0b0010, type G
   # - Data field 0b0011, type J
   # - Data field 0b0100, type F
   # - Data field 0b0110, type I
   # - Data field 0b1101, type M (LVAR)
-  def parse(<<e::1, 0b1101100::7, rest::binary>>, %{dib: %DIB{data_type: :int_or_bin, size: 16}}=ctx), do: more(e, rest, ctx, :date, coding: :type_g)
-  def parse(<<e::1, 0b1101100::7, rest::binary>>, %{dib: %DIB{data_type: _, size: _}           }=ctx), do: Vife.error(e, rest, {:invalid, "data field must be 0b0010 from Table 10 in EN 13757-3:2018 \"Meaning depends on data field. Other data fields shall be handled as invalid\""}, ctx)
-  def parse(<<e::1, 0b1101101::7, rest::binary>>, %{dib: %DIB{data_type: :int_or_bin, size: 24}}=ctx), do: more(e, rest, ctx, :time, coding: :type_j)
-  def parse(<<e::1, 0b1101101::7, rest::binary>>, %{dib: %DIB{data_type: :int_or_bin, size: 32}}=ctx), do: more(e, rest, ctx, :naive_datetime, coding: :type_f)
-  def parse(<<e::1, 0b1101101::7, rest::binary>>, %{dib: %DIB{data_type: :int_or_bin, size: 48}}=ctx), do: more(e, rest, ctx, :naive_datetime, coding: :type_i)
-  def parse(<<e::1, 0b1101101::7, rest::binary>>, %{dib: %DIB{data_type: :variable_length     }}=ctx), do: more(e, rest, ctx, :datetime, coding: :type_m)
+  def parse(<<e::1, 0b1101100::7, rest::binary>>, %DIB{data_type: :int_or_bin, size: 16}=dib, ctx), do: more(e, rest, dib, ctx, :date, coding: :type_g)
+  def parse(<<e::1, 0b1101100::7, rest::binary>>, %DIB{data_type: _, size: _}           =dib, ctx), do: Vife.error(e, rest, dib, ctx, {:invalid, "data field must be 0b0010 from Table 10 in EN 13757-3:2018 \"Meaning depends on data field. Other data fields shall be handled as invalid\""})
+  def parse(<<e::1, 0b1101101::7, rest::binary>>, %DIB{data_type: :int_or_bin, size: 24}=dib, ctx), do: more(e, rest, dib, ctx, :time, coding: :type_j)
+  def parse(<<e::1, 0b1101101::7, rest::binary>>, %DIB{data_type: :int_or_bin, size: 32}=dib, ctx), do: more(e, rest, dib, ctx, :naive_datetime, coding: :type_f)
+  def parse(<<e::1, 0b1101101::7, rest::binary>>, %DIB{data_type: :int_or_bin, size: 48}=dib, ctx), do: more(e, rest, dib, ctx, :naive_datetime, coding: :type_i)
+  def parse(<<e::1, 0b1101101::7, rest::binary>>, %DIB{data_type: :variable_length     }=dib, ctx), do: more(e, rest, dib, ctx, :datetime, coding: :type_m)
 
   # Rest after date and time
-  def parse(<<e::1, 0b1101110::7, rest::binary>>, ctx),      do: more(e, rest, ctx, :units_for_hca)
-  def parse(<<e::1, 0b1101111::7, rest::binary>>, ctx),      do: Vife.error(e, rest, {:reserved, "VIF 0b1101111 reserved for future use"}, ctx)
-  def parse(<<e::1, 0b11100::5, nn::2, rest::binary>>, ctx), do: more(e, rest, ctx, :averaging_duration, unit: decode_time_unit(nn))
-  def parse(<<e::1, 0b11101::5, nn::2, rest::binary>>, ctx), do: more(e, rest, ctx, :actuality_duration, unit: decode_time_unit(nn))
-  def parse(<<e::1, 0b1111000::7, rest::binary>>, ctx),      do: more(e, rest, ctx, :fabrication_no)
-  def parse(<<e::1, 0b1111001::7, rest::binary>>, ctx),      do: more(e, rest, ctx, :enhanced_identification)
-  def parse(<<e::1, 0b1111010::7, rest::binary>>, ctx),      do: more(e, rest, ctx, :address)
+  def parse(<<e::1, 0b1101110::7, rest::binary>>, dib, ctx),      do: more(e, rest, dib, ctx, :units_for_hca)
+  def parse(<<e::1, 0b1101111::7, rest::binary>>, dib, ctx),      do: Vife.error(e, rest, dib, ctx, {:reserved, "VIF 0b1101111 reserved for future use"})
+  def parse(<<e::1, 0b11100::5, nn::2, rest::binary>>, dib, ctx), do: more(e, rest, dib, ctx, :averaging_duration, unit: decode_time_unit(nn))
+  def parse(<<e::1, 0b11101::5, nn::2, rest::binary>>, dib, ctx), do: more(e, rest, dib, ctx, :actuality_duration, unit: decode_time_unit(nn))
+  def parse(<<e::1, 0b1111000::7, rest::binary>>, dib, ctx),      do: more(e, rest, dib, ctx, :fabrication_no)
+  def parse(<<e::1, 0b1111001::7, rest::binary>>, dib, ctx),      do: more(e, rest, dib, ctx, :enhanced_identification)
+  def parse(<<e::1, 0b1111010::7, rest::binary>>, dib, ctx),      do: more(e, rest, dib, ctx, :address)
 
   # plain-text VIF:
   # See EN 13757-3:2018(EN) - C.2
   #
-  def parse(<<e::1, 0b1111100::7, rest::binary>>, ctx) do
+  def parse(<<e::1, 0b1111100::7, rest::binary>>, dib, ctx) do
     # first we need to parse all of the extensions as well.
     # we pass in a description set to a marker we can match on it's way out of the vifes/4 again
     # to make sure it hasn't changed.
-    case more(e, rest, ctx, :plain_text_unit) do
+    case more(e, rest, dib, ctx, :plain_text_unit) do
       # the length in bytes and the ascii unit itself is found after the VIB
       # so we now need to read the unit out from the rest of the data.
       # First we get the length in the first byte:
@@ -93,9 +93,9 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableMain do
     end
   end
 
-  def parse(<<e::1, 0b111_1110::7, rest::binary>>, ctx), do: Vife.error(e, rest, "Any VIF 0x7E / 0xFE not implemented. See 6.4.1 list item d.", ctx)
+  def parse(<<e::1, 0b111_1110::7, rest::binary>>, dib, ctx), do: Vife.error(e, rest, dib, ctx, {:reserved, "Any VIF 0x7E / 0xFE not implemented. See 6.4.1 list item d."})
 
-  def parse(<<e::1, 0b111_1111::7, rest::binary>>, _ctx) do
+  def parse(<<e::1, 0b111_1111::7, rest::binary>>, _dib, _ctx) do
   # Manufacturer specific encoding, 7F / FF.
   # Rest of data-record (including VIFEs) are manufacturer specific.
   {:ok, vifes, rest} =
@@ -112,9 +112,9 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.VifTableMain do
     }, rest}
   end
 
-  def parse(<<0b1111_1011, rest::binary>>, ctx), do: FB.parse(rest, ctx)
-  def parse(<<0b1111_1101, rest::binary>>, ctx), do: FD.parse(rest, ctx)
-  def parse(<<0b1110_1111, _rest::binary>>, _ctx), do: raise "VIF 0xEF reserved for future use."
+  def parse(<<0b1111_1011, rest::binary>>, dib, ctx), do: FB.parse(rest, dib, ctx)
+  def parse(<<0b1111_1101, rest::binary>>, dib, ctx), do: FD.parse(rest, dib, ctx)
+  def parse(<<0b1110_1111, _rest::binary>>, _dib, _ctx), do: raise "VIF 0xEF reserved for future use."
 
 
 

--- a/lib/exmbus/parser/apl/data_record/value_information_block/vife.ex
+++ b/lib/exmbus/parser/apl/data_record/value_information_block/vife.ex
@@ -20,55 +20,29 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.Vife do
   @doc """
   Ignore VIFE and return {:error, reason, rest}
   """
-  def error(1, rest, reason, _ctx) do
+  def error(1, rest, _dib, _ctx, reason) do
     case consume(rest, []) do
       {:ok, _, rest} -> {:error, reason, rest}
     end
   end
 
-  def error(0, rest, reason, _ctx) do
+  def error(0, rest, _dib, _ctx, reason) do
     {:error, reason, rest}
   end
 
-  @doc """
-  Parse VIFEs into a %VIB{} struct.
-  The first argument is the extension bit from the previous byte.
-  When a function call sees a zero from the previous extension bit,
-  we know that `rest` isn't part of the VIFE and we can return the accumulated VIB and rest of data.
-  """
-  # VIFE 0bE000XXXX reserved for object actions (master to slave) (6.4.7) or for error codes (slave to master) (6.4.8)
-  # TODO move down into exts function
-  def parse(
-        1,
-        <<e::1, 0b000::3, xxxx::4, rest::binary>>,
-        %{vib: %VIB{table: :main, extensions: exts} = vib} = ctx
-      ) do
-    case direction_from_ctx(ctx) do
-      {:ok, :from_meter} ->
-        case ErrorCode.decode(xxxx) do
-          {:ok, record_error} ->
-            vib = %{vib | extensions: [{:record_error, record_error} | exts]}
-            parse(e, rest, %{ctx | vib: vib})
-
-          # for now we just pass the reserved numbers through.
-          # if they are being used it is most likely because we have not implemented them.
-          # I've already seen 0b0_1000 in use in the real world.
-          {:error, {:reserved, _} = r} ->
-            vib = %{vib | extensions: [{:record_error, r} | exts]}
-            parse(e, rest, %{ctx | vib: vib})
-        end
+  # Parse VIFEs into a %VIB{} struct.
+  # The first argument is the extension bit from the previous byte.
+  # When a function call sees a zero from the previous extension bit,
+  # we know that `rest` isn't part of the VIFE and we can return the accumulated VIB and rest of data.
+  def parse(1, rest, dib, %VIB{extensions: exts} = vib, ctx) do
+    case exts(1, rest, ctx, exts) do
+      {:ok, rest, exts} -> parse(0, rest, dib, %{vib | extensions: exts}, ctx)
     end
   end
 
-  def parse(1, rest, %{vib: %VIB{extensions: exts} = vib} = ctx) do
-    case exts(1, rest, exts) do
-      {:ok, rest, exts} -> parse(0, rest, %{ctx | vib: %{vib | extensions: exts}})
-    end
-  end
-
-  def parse(0, rest, ctx) do
-    # when no more extensions, return the vib (which we used as an accumulator so far)
-    {:ok, ctx.vib, rest}
+  def parse(0, rest, _dib, vib, _ctx) do
+    # when no more extensions, return the vib (which we used as an accumulator)
+    {:ok, vib, rest}
   end
 
   # From ctx, find layer with direction and call direction function on it:
@@ -79,156 +53,173 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.Vife do
   defp direction_from_ctx(%{dll: %Exmbus.Parser.Dll.Mbus{} = mbus}),
     do: Exmbus.Parser.Dll.Mbus.direction(mbus)
 
-  defp direction_from_ctx(%{}), do: {:error, :no_direction}
+  defp direction_from_ctx(_), do: {:error, :unknown_direction}
 
   # Table 15 — Combinable (orthogonal) VIFE-table
-  defp exts(0, rest, acc) do
+  defp exts(0, rest, _ctx, acc) do
     {:ok, rest, Enum.reverse(acc)}
   end
 
-  defp exts(1, <<e::1, 0b0010010::7, rest::binary>>, acc),
-    do: exts(e, rest, [:average_value | acc])
+  # VIFE 0bE000XXXX reserved for object actions (master to slave) (6.4.7) or for error codes (slave to master) (6.4.8)
+  defp exts(1, <<e::1, 0b000::3, xxxx::4, rest::binary>>, ctx, acc) do
+    case direction_from_ctx(ctx) do
+      res when res in [{:ok, :from_meter}, {:error, :unknown_direction}] ->
+        case ErrorCode.decode(xxxx) do
+          {:ok, record_error} ->
+            exts(e, rest, ctx, [{:record_error, record_error} | acc])
+
+          # for now we just pass the reserved numbers through.
+          # if they are being used it is most likely because we have not implemented them.
+          # I've already seen 0b0_1000 in use in the real world.
+          {:error, {:reserved, _} = r} ->
+            exts(e, rest, ctx, [{:record_error, r} | acc])
+        end
+    end
+  end
+
+  defp exts(1, <<e::1, 0b0010010::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:average_value | acc])
 
   # EN 13757-3:2018 table 15
-  defp exts(1, <<e::1, 0b0010011::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:compact_profile, :inverse} | acc])
+  defp exts(1, <<e::1, 0b0010011::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:compact_profile, :inverse} | acc])
 
   # EN 13757-3:2018 table 15
-  defp exts(1, <<e::1, 0b0010100::7, rest::binary>>, acc),
-    do: exts(e, rest, [:standard_conform | acc])
+  defp exts(1, <<e::1, 0b0010100::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:standard_conform | acc])
 
   # EN 13757-3:2018 table 15
-  defp exts(1, <<e::1, 0b0011101::7, rest::binary>>, acc),
-    do: exts(e, rest, [:standard_conform | acc])
+  defp exts(1, <<e::1, 0b0011101::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:standard_conform | acc])
 
   # EN 13757-3:2018 table 15
-  defp exts(1, <<e::1, 0b0011110::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:compact_profile, :register_numbers} | acc])
+  defp exts(1, <<e::1, 0b0011110::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:compact_profile, :register_numbers} | acc])
 
   # EN 13757-3:2018 table 15
-  defp exts(1, <<e::1, 0b0011111::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:compact_profile, :compact_profile} | acc])
+  defp exts(1, <<e::1, 0b0011111::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:compact_profile, :compact_profile} | acc])
 
-  defp exts(1, <<e::1, 0b0100000::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :interval, :second} | acc])
+  defp exts(1, <<e::1, 0b0100000::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :interval, :second} | acc])
 
-  defp exts(1, <<e::1, 0b0100001::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :interval, :minute} | acc])
+  defp exts(1, <<e::1, 0b0100001::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :interval, :minute} | acc])
 
-  defp exts(1, <<e::1, 0b0100010::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :interval, :hour} | acc])
+  defp exts(1, <<e::1, 0b0100010::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :interval, :hour} | acc])
 
-  defp exts(1, <<e::1, 0b0100011::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :interval, :day} | acc])
+  defp exts(1, <<e::1, 0b0100011::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :interval, :day} | acc])
 
-  defp exts(1, <<e::1, 0b0100100::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :interval, :week} | acc])
+  defp exts(1, <<e::1, 0b0100100::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :interval, :week} | acc])
 
-  defp exts(1, <<e::1, 0b0100101::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :interval, :month} | acc])
+  defp exts(1, <<e::1, 0b0100101::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :interval, :month} | acc])
 
-  defp exts(1, <<e::1, 0b0100110::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :interval, :year} | acc])
+  defp exts(1, <<e::1, 0b0100110::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :interval, :year} | acc])
 
-  defp exts(1, <<e::1, 0b0100111::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :misc, :revolution_or_measurement} | acc])
+  defp exts(1, <<e::1, 0b0100111::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :misc, :revolution_or_measurement} | acc])
 
-  defp exts(1, <<e::1, 0b010100::6, p::1, rest::binary>>, acc) do
+  defp exts(1, <<e::1, 0b010100::6, p::1, rest::binary>>, ctx, acc) do
     # Increment per input pulse on input channel number p
-    exts(e, rest, [{:per, :input_pulse, {:channel_number, p}} | acc])
+    exts(e, rest, ctx, [{:per, :input_pulse, {:channel_number, p}} | acc])
   end
 
-  defp exts(1, <<e::1, 0b010101::6, p::1, rest::binary>>, acc) do
+  defp exts(1, <<e::1, 0b010101::6, p::1, rest::binary>>, ctx, acc) do
     # Increment per output pulse on output channel number p
-    exts(e, rest, [{:per, :output_pulse, {:channel_number, p}} | acc])
+    exts(e, rest, ctx, [{:per, :output_pulse, {:channel_number, p}} | acc])
   end
 
-  defp exts(1, <<e::1, 0b0101100::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "l"} | acc])
+  defp exts(1, <<e::1, 0b0101100::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "l"} | acc])
 
-  defp exts(1, <<e::1, 0b0101101::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "m3"} | acc])
+  defp exts(1, <<e::1, 0b0101101::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "m3"} | acc])
 
-  defp exts(1, <<e::1, 0b0101110::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "kg"} | acc])
+  defp exts(1, <<e::1, 0b0101110::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "kg"} | acc])
 
-  defp exts(1, <<e::1, 0b0101111::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "K"} | acc])
+  defp exts(1, <<e::1, 0b0101111::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "K"} | acc])
 
-  defp exts(1, <<e::1, 0b0110000::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "kWh"} | acc])
+  defp exts(1, <<e::1, 0b0110000::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "kWh"} | acc])
 
-  defp exts(1, <<e::1, 0b0110001::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "GJ"} | acc])
+  defp exts(1, <<e::1, 0b0110001::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "GJ"} | acc])
 
-  defp exts(1, <<e::1, 0b0110010::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "kW"} | acc])
+  defp exts(1, <<e::1, 0b0110010::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "kW"} | acc])
 
-  defp exts(1, <<e::1, 0b0110011::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "Kl"} | acc])
+  defp exts(1, <<e::1, 0b0110011::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "Kl"} | acc])
 
-  defp exts(1, <<e::1, 0b0110100::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "V"} | acc])
+  defp exts(1, <<e::1, 0b0110100::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "V"} | acc])
 
-  defp exts(1, <<e::1, 0b0110101::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:per, :unit, "A"} | acc])
+  defp exts(1, <<e::1, 0b0110101::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:per, :unit, "A"} | acc])
 
-  defp exts(1, <<e::1, 0b0110110::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:multiplied_by, "s"} | acc])
+  defp exts(1, <<e::1, 0b0110110::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:multiplied_by, "s"} | acc])
 
-  defp exts(1, <<e::1, 0b0110111::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:multiplied_by, "(s/V)"} | acc])
+  defp exts(1, <<e::1, 0b0110111::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:multiplied_by, "(s/V)"} | acc])
 
-  defp exts(1, <<e::1, 0b0111000::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:multiplied_by, "(s/A)"} | acc])
+  defp exts(1, <<e::1, 0b0111000::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:multiplied_by, "(s/A)"} | acc])
 
-  defp exts(1, <<e::1, 0b0111001::7, rest::binary>>, acc),
-    do: exts(e, rest, [:start_date_slash_time_of | acc])
+  defp exts(1, <<e::1, 0b0111001::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:start_date_slash_time_of | acc])
 
-  defp exts(1, <<e::1, 0b0111010::7, rest::binary>>, acc),
-    do: exts(e, rest, [:vif_contains_uncorrected_unit_or_value | acc])
+  defp exts(1, <<e::1, 0b0111010::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:vif_contains_uncorrected_unit_or_value | acc])
 
-  defp exts(1, <<e::1, 0b0111011::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:accumulation_only, :forward_flow} | acc])
+  defp exts(1, <<e::1, 0b0111011::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:accumulation_only, :forward_flow} | acc])
 
-  defp exts(1, <<e::1, 0b0111100::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:accumulation_only, :backward_flow} | acc])
+  defp exts(1, <<e::1, 0b0111100::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:accumulation_only, :backward_flow} | acc])
 
-  defp exts(1, <<e::1, 0b0111101::7, rest::binary>>, acc),
-    do: exts(e, rest, [:non_metric | acc])
+  defp exts(1, <<e::1, 0b0111101::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:non_metric | acc])
 
-  defp exts(1, <<e::1, 0b0111110::7, rest::binary>>, acc),
-    do: exts(e, rest, [:value_at_base_condition | acc])
+  defp exts(1, <<e::1, 0b0111110::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:value_at_base_condition | acc])
 
-  defp exts(1, <<e::1, 0b0111111::7, rest::binary>>, acc),
-    do: exts(e, rest, [:obis_declaration | acc])
+  defp exts(1, <<e::1, 0b0111111::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:obis_declaration | acc])
 
-  defp exts(1, <<e::1, 0b100::3, 0::1, 000::3, rest::binary>>, acc),
-    do: exts(e, rest, [{:limit_value, :lower} | acc])
+  defp exts(1, <<e::1, 0b100::3, 0::1, 000::3, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:limit_value, :lower} | acc])
 
-  defp exts(1, <<e::1, 0b100::3, 1::1, 000::3, rest::binary>>, acc),
-    do: exts(e, rest, [{:limit_value, :upper} | acc])
+  defp exts(1, <<e::1, 0b100::3, 1::1, 000::3, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:limit_value, :upper} | acc])
 
-  defp exts(1, <<e::1, 0b100::3, 0::1, 001::3, rest::binary>>, acc),
-    do: exts(e, rest, [{:number_of_exceeds_of_limit_value, :lower} | acc])
+  defp exts(1, <<e::1, 0b100::3, 0::1, 001::3, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:number_of_exceeds_of_limit_value, :lower} | acc])
 
-  defp exts(1, <<e::1, 0b100::3, 1::1, 001::3, rest::binary>>, acc),
-    do: exts(e, rest, [{:number_of_exceeds_of_limit_value, :upper} | acc])
+  defp exts(1, <<e::1, 0b100::3, 1::1, 001::3, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:number_of_exceeds_of_limit_value, :upper} | acc])
 
   # E100 uf1b
   # Date (/time) of: b=0:begin, b=1:end, f=0:first, f=1:last, u=0:lower, u=1:upper limit exceed
-  defp exts(1, <<e::1, 0b100::3, u::1, f::1, 1::1, b::1, rest::binary>>, acc) do
+  defp exts(1, <<e::1, 0b100::3, u::1, f::1, 1::1, b::1, rest::binary>>, ctx, acc) do
     begin_end = if b == 0, do: :begin, else: :end
     first_last = if f == 0, do: :first, else: :last
     upper_lower = if u == 0, do: :lower, else: :upper
     extension = {:limit_exceed, upper_lower, first_last, begin_end}
-    exts(e, rest, [extension | acc])
+    exts(e, rest, ctx, [extension | acc])
   end
 
   # E101 ufnn
   # Duration of limit exceed: f=0:first, f=1:last, u=0:lower, u=1:upper limit exceed,
   # nn=00:second, nn=01:minute, nn=10:hour, nn=11:day
-  defp exts(1, <<e::1, 0b101::3, u::1, f::1, nn::2, rest::binary>>, acc) do
+  defp exts(1, <<e::1, 0b101::3, u::1, f::1, nn::2, rest::binary>>, ctx, acc) do
     first_last = if f == 0, do: :first, else: :last
     upper_lower = if u == 0, do: :lower, else: :upper
 
@@ -241,13 +232,13 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.Vife do
       end
 
     extension = {:duration_of_limit_exceed, upper_lower, first_last, duration_type}
-    exts(e, rest, [extension | acc])
+    exts(e, rest, ctx, [extension | acc])
   end
 
   # E110 0fnn
   # Duration of d
   # f=0:first, f=1:last, nn=00:second, nn=01:minute, nn=10:hour, nn=11:day
-  defp exts(1, <<e::1, 0b1100::4, f::1, nn::2, rest::binary>>, acc) do
+  defp exts(1, <<e::1, 0b1100::4, f::1, nn::2, rest::binary>>, ctx, acc) do
     first_last = if f == 0, do: :first, else: :last
 
     date_type =
@@ -259,45 +250,70 @@ defmodule Exmbus.Parser.Apl.DataRecord.ValueInformationBlock.Vife do
       end
 
     extension = {:duration_of_d, first_last, date_type}
-    exts(e, rest, [extension | acc])
+    exts(e, rest, ctx, [extension | acc])
   end
 
-  defp exts(1, <<_::1, 0b1101::4, _u::1, 00::2, _rest::binary>>, _acc),
-    do: raise("E110 1u00 Value during lower (u = 0), upper (u = 1) limit exceed not supported")
-
-  defp exts(1, <<e::1, 0b110_1001::7, rest::binary>>, acc),
-    do: exts(e, rest, [:leakage_values | acc])
-
-  defp exts(1, <<e::1, 0b110_1101::7, rest::binary>>, acc),
-    do: exts(e, rest, [:overflow_values | acc])
-
-  defp exts(1, <<_::1, 0b110_1::4, _u::1, 00::2, _rest::binary>>, _acc),
-    do: raise("E110 1f1b 'Date (/time) of' not supported")
-
-  defp exts(1, <<e::1, 0b111_0::4, nnn::3, rest::binary>>, acc),
-    do: exts(e, rest, [{:multiplicative_correction_factor, pow10to(nnn - 6)} | acc])
-
-  defp exts(1, <<e::1, 0b111_10::5, nn::2, rest::binary>>, acc),
-    do: exts(e, rest, [{:additive_correction_constant, pow10to(nn - 3)} | acc])
-
-  defp exts(1, <<_::1, 0b111_1100::7, _rest::binary>>, _acc),
-    do: raise("E111 1100 Extension of combinable (orthogonal) VIFE-Code not supported")
-
-  defp exts(1, <<e::1, 0b111_1101::7, rest::binary>>, acc),
-    do: exts(e, rest, [{:multiplicative_correction_factor, 103} | acc])
-
-  defp exts(1, <<e::1, 0b111_1110::7, rest::binary>>, acc),
-    do: exts(e, rest, [:future_value | acc])
-
-  defp exts(1, <<e::1, 0b111_1111::7, rest::binary>>, acc),
-    do: exts_manufacturer_specific(e, rest, acc)
-
-  defp exts_manufacturer_specific(0, rest, acc) do
-    exts(0, rest, acc)
+  defp exts(1, <<e::1, 0b110_1::4, u::1, 00::2, rest::binary>>, ctx, acc) do
+    bound = if(u == 0, do: :lower, else: :upper)
+    exts(e, rest, ctx, [{:value_during_limit_exceed, bound} | acc])
   end
 
-  defp exts_manufacturer_specific(1, <<e::1, vife::7, rest::binary>>, acc) do
-    exts_manufacturer_specific(e, rest, [{:manufacturer_specific_vife, vife} | acc])
+  defp exts(1, <<e::1, 0b110_1001::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:leakage_values | acc])
+
+  defp exts(1, <<e::1, 0b110_1101::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:overflow_values | acc])
+
+  defp exts(1, <<e::1, 0b110_1::4, f::1, 1::1, b::1, rest::binary>>, ctx, acc) do
+    begin_end = if b == 0, do: :begin, else: :end
+    first_last = if f == 0, do: :first, else: :last
+    extension = {:date_time_of, first_last, begin_end}
+    exts(e, rest, ctx, [extension | acc])
+  end
+
+  defp exts(1, <<e::1, 0b111_0::4, nnn::3, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:multiplicative_correction_factor, pow10to(nnn - 6)} | acc])
+
+  defp exts(1, <<e::1, 0b111_10::5, nn::2, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:additive_correction_constant, pow10to(nn - 3)} | acc])
+
+  defp exts(1, <<e::1, 0b111_1100::7, rest::binary>>, ctx, acc),
+    do: exts_table_fc(e, rest, ctx, acc)
+
+  defp exts(1, <<e::1, 0b111_1101::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [{:multiplicative_correction_factor, 103} | acc])
+
+  defp exts(1, <<e::1, 0b111_1110::7, rest::binary>>, ctx, acc),
+    do: exts(e, rest, ctx, [:future_value | acc])
+
+  defp exts(1, <<e::1, 0b111_1111::7, rest::binary>>, ctx, acc),
+    do: exts_manufacturer_specific(e, rest, ctx, acc)
+
+  # for now, just write a "we do not support VIFE extension table FC" extension:
+  defp exts_table_fc(1, <<e::1, unknown::7, rest::binary>>, ctx, acc) do
+    exts(e, rest, ctx, [{:unsupported_vife_extension_table_fc, unknown} | acc])
+  end
+
+  # this should not happen, because it is pointless to move to the extension table and then not have an extension in here,
+  # but we don't want to crash on it, so we just continue.
+  defp exts_table_fc(0, rest, ctx, acc) do
+    exts(0, rest, ctx, acc)
+  end
+
+  # I've considered having this fall-through, but I actually think it is possible to handle
+  # all VIFE cases instead, and give more specific errors, so for now, we'll do that.
+  # defp exts(1, rest, ctx, acc) do
+  #   case consume(rest, []) do
+  #     {:ok, unknown_vifes, rest} -> exts(0, rest, ctx, [{:unknown_vifes, unknown_vifes} | acc])
+  #   end
+  # end
+
+  defp exts_manufacturer_specific(0, rest, ctx, acc) do
+    exts(0, rest, ctx, acc)
+  end
+
+  defp exts_manufacturer_specific(1, <<e::1, vife::7, rest::binary>>, ctx, acc) do
+    exts_manufacturer_specific(e, rest, ctx, [{:manufacturer_specific_vife, vife} | acc])
   end
 
   defp pow10to(power) do

--- a/lib/exmbus/parser/apl/full_frame.ex
+++ b/lib/exmbus/parser/apl/full_frame.ex
@@ -3,56 +3,62 @@ defmodule Exmbus.Parser.Apl.FullFrame do
   Parser for a full frame.
 
   A FullFrame contains a list of data records.
+  The parser expects the remaining binary to be the APL records,
+  and will recursively call `DataRecord.parse/1` until it runs out of bytes.
   """
 
-  alias Exmbus.Parser.Context
-  alias Exmbus.Parser.Apl.DataRecord.InvalidDataRecord
   alias Exmbus.Parser.Apl.DataRecord
+  alias Exmbus.Parser.Apl.DataRecord.InvalidDataRecord
   alias Exmbus.Parser.Apl.FormatFrame
+  alias Exmbus.Parser.Context
 
   defstruct records: [],
             manufacturer_bytes: nil
 
   def parse(%Context{} = ctx) do
-    parse_full_frame(ctx.bin, ctx, [])
+    # recursively parse records into the accumulator.
+    # we consume the entire binary from the context here,
+    # since we expect to be able to handle all of it internally.
+    parse_records(%{ctx | bin: <<>>}, ctx.bin, [])
   end
 
-  defp parse_full_frame(<<>>, ctx, acc) do
-    finalize_full_frame(<<>>, ctx, acc)
+  # when we run out of bytes, we finalize the FullFrame parse
+  defp parse_records(ctx, <<>>, acc) do
+    finalize(ctx, <<>>, acc)
   end
 
-  defp parse_full_frame(bin, ctx, acc) do
+  defp parse_records(%{} = ctx, bin, acc) do
     case DataRecord.parse(bin, ctx) do
       {:ok, %DataRecord{} = data_record, rest} ->
-        parse_full_frame(rest, ctx, [data_record | acc])
+        parse_records(ctx, rest, [data_record | acc])
 
       {:ok, %InvalidDataRecord{} = data_record, rest} ->
-        parse_full_frame(rest, ctx, [data_record | acc])
+        parse_records(ctx, rest, [data_record | acc])
 
       # just skip the idle filler
       {:special_function, :idle_filler, rest} ->
-        parse_full_frame(rest, ctx, acc)
+        parse_records(ctx, rest, acc)
 
       # manufacturer specific data is the rest of the APL data
       {:special_function, {:manufacturer_specific, :to_end}, rest} ->
-        finalize_full_frame(rest, ctx, acc)
+        finalize(ctx, rest, acc)
 
       {:special_function, {:manufacturer_specific, :more_records_follow}, rest} ->
-        finalize_full_frame(rest, ctx, acc)
+        finalize(ctx, rest, acc)
 
       {:error, _reason, _rest} = e ->
         e
     end
   end
 
-  defp finalize_full_frame(rest, %{} = ctx, acc) do
+  defp finalize(%{} = ctx, rest, acc) do
     full_frame = %__MODULE__{
       records: Enum.reverse(acc),
       # all remaining bytes are manufacturer specific:
       manufacturer_bytes: rest
     }
 
-    {:next, %{ctx | bin: <<>>, apl: full_frame}}
+    {:next, %{ctx | apl: full_frame}}
   end
 
   def format_signature(%__MODULE__{} = ff) do

--- a/lib/exmbus/parser/context.ex
+++ b/lib/exmbus/parser/context.ex
@@ -16,12 +16,6 @@ defmodule Exmbus.Parser.Context do
           tpl: any,
           apl: any,
           #
-          dib: any,
-          vib: any,
-          # private storage map for passing data between handlers,
-          # user should not interact with this map directly.
-          private: %{},
-          #
           errors: [any]
         }
 
@@ -63,18 +57,6 @@ defmodule Exmbus.Parser.Context do
     afl: nil,
     tpl: nil,
     apl: nil,
-    # state for when parsing data record:
-    # TODO: move to it's own ACC so it doesnt polute the state?
-    # #reason for keeping it here is that it is useful
-    # for debugging when parsing fails, but maybe
-    # the errors should have more information?
-    # otherwise, maybe have a generic "current parse state" field
-    # that other layers can use?
-    dib: nil,
-    vib: nil,
-    # private storage for passing data between handlers
-    # user should not interact with this map directly.
-    private: %{},
     # error and warning accumulator
     errors: [],
     warnings: []

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Exmbus.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.6.0-rc.0"
   @source_url "https://github.com/tudborg/exmbus"
 
   def project do

--- a/test/parser/apl/data_record/unhandled_vife_test.exs
+++ b/test/parser/apl/data_record/unhandled_vife_test.exs
@@ -1,0 +1,16 @@
+defmodule Parser.Apl.DataRecord.UnhandledVifeTest do
+  use ExUnit.Case, async: true
+
+  test "Even if we haven't implemented a specific VIFE, it should not crash the parser" do
+    assert {:ok, ctx} =
+             [
+               bin: Base.decode16!("0DFD8E80FC0107302E34322E3142"),
+               handlers: [&Exmbus.Parser.Apl.parse/1]
+             ]
+             |> Exmbus.Parser.Context.new()
+             |> Exmbus.Parser.parse()
+
+    assert [firmware_version_record] = ctx.apl.records
+    assert length(firmware_version_record.header.vib.extensions) == 2
+  end
+end

--- a/test/parser/apl/data_record/value_information_block_test.exs
+++ b/test/parser/apl/data_record/value_information_block_test.exs
@@ -12,7 +12,9 @@ defmodule Parser.Apl.DataRecord.ValueInformationBlockTest do
       <<0::1, 0b1101111::7>> = vib_bytes ->
         test "reserved: #{i}" do
           bin = unquote(vib_bytes)
-          assert {:error, {:reserved, _}, <<>>} = VIB.parse(bin, [])
+
+          assert {:error, {:reserved, _}, <<>>} =
+                   VIB.parse(bin, %DIB{data_type: :int_or_bin, size: 16}, Context.new())
         end
 
       <<_::8>> = vib_bytes ->
@@ -28,7 +30,7 @@ defmodule Parser.Apl.DataRecord.ValueInformationBlockTest do
                 %DIB{data_type: :int_or_bin, size: 32}
             end
 
-          assert {:ok, vib, <<>>} = VIB.parse(bin, Context.new(dib: dib))
+          assert {:ok, vib, <<>>} = VIB.parse(bin, dib, Context.new())
           assert {:ok, ^bin} = VIB.unparse(vib)
         end
     end

--- a/test/regressions/record_error_none_test.exs
+++ b/test/regressions/record_error_none_test.exs
@@ -1,0 +1,24 @@
+defmodule Regressions.RecordErrorNoneTest do
+  @moduledoc """
+  This test came about due to a real world record from an ABB meter that used a
+  VIFE for record_error=none, but not as the first VIFE. The old way of parsing this
+  special-case was handled in such a way that only the first extension location would allow this.
+  """
+  use ExUnit.Case, async: true
+
+  test "Record error none VIFE should be handled correctly" do
+    assert {:ok, ctx} =
+             [
+               bin: Base.decode16!("0DFD8E0007302E34322E3142"),
+               handlers: [&Exmbus.Parser.Apl.parse/1]
+             ]
+             |> Exmbus.Parser.Context.new()
+             |> Exmbus.Parser.parse()
+
+    assert [firmware_version_record] = ctx.apl.records
+    assert firmware_version_record.header.vib.description == :firmware_version_number
+    assert firmware_version_record.header.vib.extensions == [{:record_error, :none}]
+    # the record also contained this value, but it isn't relevant to this specific test:
+    assert firmware_version_record.data == "0.42.1B"
+  end
+end


### PR DESCRIPTION
This is the initial work to allow data record parsing access to the parsing context.

I've removed the `dib` and `vib` accumulators on the context since that is internal to parsing a data record.

I've also removed the `private` map since it wasn't used.

This also prepares a 0.6.0-rc.0 release.

